### PR TITLE
Make `load_archive` operate on serialization directories. (#2554)

### DIFF
--- a/allennlp/tests/models/archival_test.py
+++ b/allennlp/tests/models/archival_test.py
@@ -9,6 +9,22 @@ from allennlp.common.testing import AllenNlpTestCase
 from allennlp.commands.train import train_model
 from allennlp.models.archival import load_archive, archive_model
 
+def assert_models_equal(model, model2):
+    # check that model weights are the same
+    keys = set(model.state_dict().keys())
+    keys2 = set(model2.state_dict().keys())
+
+    assert keys == keys2
+
+    for key in keys:
+        assert torch.equal(model.state_dict()[key], model2.state_dict()[key])
+
+    # check that vocabularies are the same
+    vocab = model.vocab
+    vocab2 = model2.vocab
+
+    assert vocab._token_to_index == vocab2._token_to_index  # pylint: disable=protected-access
+    assert vocab._index_to_token == vocab2._index_to_token  # pylint: disable=protected-access
 
 class ArchivalTest(AllenNlpTestCase):
     def setUp(self):
@@ -56,21 +72,7 @@ class ArchivalTest(AllenNlpTestCase):
         archive = load_archive(archive_path)
         model2 = archive.model
 
-        # check that model weights are the same
-        keys = set(model.state_dict().keys())
-        keys2 = set(model2.state_dict().keys())
-
-        assert keys == keys2
-
-        for key in keys:
-            assert torch.equal(model.state_dict()[key], model2.state_dict()[key])
-
-        # check that vocabularies are the same
-        vocab = model.vocab
-        vocab2 = model2.vocab
-
-        assert vocab._token_to_index == vocab2._token_to_index  # pylint: disable=protected-access
-        assert vocab._index_to_token == vocab2._index_to_token  # pylint: disable=protected-access
+        assert_models_equal(model, model2)
 
         # check that params are the same
         params2 = archive.config
@@ -111,3 +113,39 @@ class ArchivalTest(AllenNlpTestCase):
 
         # The validation data path should be the same though.
         assert params.get('validation_data_path') == str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv')
+
+    def test_loading_serialization_directory(self):
+        # copy params, since they'll get consumed during training
+        params_copy = copy.deepcopy(self.params.as_dict())
+
+        # `train_model` should create an archive
+        serialization_dir = self.TEST_DIR / 'serialization'
+        model = train_model(self.params, serialization_dir=serialization_dir)
+
+        # load from the serialization directory itself
+        archive = load_archive(serialization_dir)
+        model2 = archive.model
+
+        assert_models_equal(model, model2)
+
+        # check that params are the same
+        params2 = archive.config
+        assert params2.as_dict() == params_copy
+
+    def test_loading_serialization_directory_with_extra_files(self):
+
+        serialization_dir = self.TEST_DIR / 'serialization'
+
+        # Train a model
+        train_model(self.params, serialization_dir=serialization_dir)
+
+        # Archive model, and also archive the training data
+        original_train_data_path = str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv')
+        files_to_archive = {"train_data_path": original_train_data_path}
+        archive_model(serialization_dir=serialization_dir, files_to_archive=files_to_archive)
+
+        archive = load_archive(serialization_dir)
+        params = archive.config
+
+        # We're loading from a directory, so retain the original path.
+        assert params.get('train_data_path') == original_train_data_path


### PR DESCRIPTION
- Fixes https://github.com/allenai/allennlp/issues/1052.
- Files like ELMo weight files aren't added to the serialization dir, but are added to the archive with `add_file_to_archive`.
- This results in misleading errors when using `load_archive` as it will attempt to load a serialization dir.
- Solution: Retain original paths when we're loading from a directory.
- Drive by fix for overrides not overriding.